### PR TITLE
Add embed

### DIFF
--- a/src/computation.ts
+++ b/src/computation.ts
@@ -1,4 +1,4 @@
-import { Env, Capabilities, chainEnv, pureEnv, resumeNow, Resume, Use } from './env'
+import { Env, Capabilities, chainEnv, pureEnv, resumeNow, Resume, Use, Embed } from './env'
 
 // A Computation is a sequence of effects, each of which requires a set
 // of capabilities. Between those effects, there can be any number of
@@ -57,3 +57,9 @@ export const get = <C>() => fromEnv<C, C>(resumeNow)
 export const use = <Y extends Env<any, N>, R, N, C> (cg: Computation<Y, R, N>, c: C): Computation<Use<Y, C>, R, R> =>
   fromEnv((c0: Capabilities<Use<Y, C>>) =>
     runComputation(cg)({ ...c0 as any, ...c })) as Computation<Use<Y, C>, R, R>
+
+// Adapt a Computation that requires one set of capabilities to
+// an environment that provides a different set.
+export const embed = <Y extends Env<any, N>, R, N, C>(cg: Computation<Y, R, N>, f: (c: C) => Capabilities<Y>): Computation<Embed<Y, C>, R, R> =>
+  fromEnv((c: C) =>
+    runComputation(cg)(f(c))) as Computation<Embed<Y, C>, R, R>

--- a/src/env.ts
+++ b/src/env.ts
@@ -17,6 +17,13 @@ export type Use<E, CP> =
   : C extends CP ? Env<Omit<C, keyof CP>, A>
   : E : E
 
+// Change the capabilities of an Env
+// Useful for changing the capabilities of Env unions
+// Embed<Env<C1, A> | Env<C2, B>, C3> = Env<C3, A> | Env<C3, B>
+export type Embed<E, C> =
+  E extends Env<any, infer A>
+  ? Env<C, A> : never
+
 // Get the type of capabilities required by Envs
 export type Capabilities<E> = U2I<CapabilitiesOf<E>>
 type U2I<U> =


### PR DESCRIPTION
Add `embed`, which adapts a Computation that requires one set of capabilities to be usable in an environment that provides a different set.  Effectively, contramap on the complete set of capabilities a Computation requires.

The type-level `Embed` is heavy-handed, but I haven't found a way to be more selective in changing only the specific Envs that actually need to be changed.  In practice, so far, that hasn't been a problem, though, since `embed` still guarantees that the complete set of capabilities has to be satisfied.

* I'm not sure which parameter order turns out to be most intuitive, but given that `use` is similar, I decided to match its order.
* I like the name `embed`, but I'm not sure if it's helpful 😄 Hopefully, the types communicate more than the name.