### PR TITLE
Add timer module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ node_modules/
 .env
 
 dist/
+lib/
 .rts2_cache_*/
 experiments/
 .vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -41,8 +41,6 @@ node_modules/
 # dotenv environment variables file
 .env
 
-dist/
-lib/
 .rts2_cache_*/
 experiments/
 .vscode/

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,10 +16,32 @@
       "integrity": "sha512-+ytCkGcBtHZ3V2r2Z06AncYO8jz46UEamcspGoU8lHcEbpn6J77QK0vdWvChsclg/tM5XIJC5tnjmPp7Eq6Obg==",
       "dev": true
     },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
     "diff": {
@@ -28,11 +50,80 @@
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true
     },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
     "make-error": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
       "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
       "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
     },
     "source-map": {
       "version": "0.6.1",
@@ -67,6 +158,12 @@
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
       "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
     "yn": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fx-ts",
   "version": "1.3.2",
   "description": "Computational environments for TypeScript",
-  "main": "lib/index.js",
+  "main": "index.js",
   "type": "module",
   "repository": {
     "type": "git",
@@ -11,16 +11,20 @@
   "scripts": {
     "test": "tsc --noEmit",
     "prepublishOnly": "npm run build",
+    "postpublish": "rimraf *.js *.js.map *.d.ts",
     "build": "tsc"
   },
   "files": [
-    "dist"
+    "*.js",
+    "*.js.map",
+    "*.d.ts"
   ],
   "keywords": [],
   "author": "",
   "license": "MIT",
   "devDependencies": {
     "@types/node": "13.9.1",
+    "rimraf": "^3.0.2",
     "ts-node": "8.6.2",
     "typescript": "3.8.3"
   }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fx-ts",
   "version": "1.3.2",
   "description": "Computational environments for TypeScript",
-  "main": "dist/index.js",
+  "main": "lib/index.js",
   "type": "module",
   "repository": {
     "type": "git",

--- a/src/timer.ts
+++ b/src/timer.ts
@@ -1,0 +1,10 @@
+import { Resume } from './env'
+import { op, Computation, co } from './computation'
+import { race } from './array'
+
+export type Delay = { delay(ms: number): Resume<void> }
+export const delay = (ms: number) => op<Delay>(c => c.delay(ms))
+
+export const timeout = co(function* <Y, R, N>(ms: number, c: Computation<Y, R, N>) {
+  return yield* race(c, delay(ms))
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,8 +10,8 @@
     "strict": true,
     "sourceMap": true,
     "declaration": true,
-    "declarationDir": "dist",
-    "outDir": "dist",
+    "declarationDir": "lib",
+    "outDir": "lib",
     "typeRoots": [
       "node_modules/@types"
     ]
@@ -21,6 +21,6 @@
     "examples/**/*.ts"
   ],
   "include": [
-    "src",
+    "src"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,8 +10,8 @@
     "strict": true,
     "sourceMap": true,
     "declaration": true,
-    "declarationDir": "lib",
-    "outDir": "lib",
+    "declarationDir": ".",
+    "outDir": ".",
     "typeRoots": [
       "node_modules/@types"
     ]


### PR DESCRIPTION
Add timer as a separately importable module, not exported from index.  This is an experiment to see if `import { delay } from 'fx-ts/timer'` is a reasonable approach to modularity without resorting to multiple _packages_ plus lerna and/or yarn workspaces.

The timer module exports a delay capability with no implementation, and a timeout combinator as the trivial combination of delay and race.  The fp-to-the-max example shows usage of both delay and timeout.