### PR TITLE
Propagate cancel via continuation return by default

### DIFF
--- a/src/array.ts
+++ b/src/array.ts
@@ -1,5 +1,5 @@
 import { Computation, Yield, Next, Return, op, runComputation } from './computation'
-import { Capabilities, resumeLater, Env, runResume } from './env'
+import { Capabilities, Env, runResume, resume, uncancelable } from './env'
 
 // Arrays and tuples of computations
 // Strongly-typed variadic operations support homogeneous arrays as well as
@@ -16,14 +16,14 @@ type Writeable<T> = { -readonly [P in keyof T]: T[P] }
 
 // Turn a list of computations into a computation of a list
 export const zip = <Computations extends readonly Computation<any, any, any>[]>(...cs: Computations): Computation<Env<AllCapabilities<Computations>, AllResult<Computations>>, AllResult<Computations>, AllNexts<Computations>> =>
-  op((c: AllCapabilities<Computations>) => resumeLater<AllResult<Computations>>(k => {
+  op((c: AllCapabilities<Computations>) => resume<AllResult<Computations>>(k => {
     let remaining = cs.length
     const results = Array(remaining) as Writeable<AllResult<Computations>>
 
     const cancels = cs.map((computation: Computations[typeof i], i) =>
       runResume(runComputation(computation)(c), (x: AnyResult<Computations>) => {
         results[i] = x
-        if (--remaining === 0) k(results)
+        return --remaining === 0 ? k(results) : uncancelable
       }))
 
     return () => cancels.forEach(c => c())
@@ -32,11 +32,11 @@ export const zip = <Computations extends readonly Computation<any, any, any>[]>(
 // Return computation equivalent to the input computation that produces the earliest result
 // TODO: Consider requiring the input computations to be Async
 export const race = <Computations extends readonly Computation<any, any, any>[]>(...cs: Computations): Computation<Env<AllCapabilities<Computations>, AnyResult<Computations>>, AnyResult<Computations>, any> =>
-  op((c: AllCapabilities<Computations>) => resumeLater<AnyResult<Computations>>(k => {
+  op((c: AllCapabilities<Computations>) => resume<AnyResult<Computations>>(k => {
     const cancels = cs.map((computation: Computations[number]) =>
       runResume(runComputation(computation)(c), (x: AnyResult<Computations>) => {
         cancelAll()
-        k(x)
+        return k(x)
       }))
 
     const cancelAll = () => cancels.forEach(c => c())

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,6 +1,6 @@
-import { Cancel, runResume, Pure } from './env'
+import { Cancel, runResume, Pure, uncancelable } from './env'
 import { Computation, runComputation } from './computation'
 
-export const unsafeRun = <Y extends Pure<any>, R, N>(c: Computation<Y, R, N>, f: (r: R) => void = () => {}): Cancel =>
+export const unsafeRun = <Y extends Pure<any>, R, N>(c: Computation<Y, R, N>, f: (r: R) => Cancel = () => uncancelable): Cancel =>
   runResume(runComputation(c)({} as never), f)
   


### PR DESCRIPTION
Breaking change

Simplify cancelation chaining base case by returning Cancel from continuations.  When implementing capabilities that need to integrate with APIs that don't support that model, you can opt in to a void-returning cancelation, which incurs the extra burden of handling cancelation in whatever way the API requires.

