### PR TITLE
POC: Add early return effect support

### DIFF
--- a/examples/echo-console.ts
+++ b/examples/echo-console.ts
@@ -2,10 +2,10 @@ import { co, unsafeRun, resumeLater, resumeNow, use, Resume, op } from '../src'
 import { EOL } from 'os'
 import { createInterface } from 'readline'
 
-type Print = { print(s: string): Resume<void> }
+type Print = { print(s: string): Resume<never, void> }
 const print = (s: string) => op<Print>(c => c.print(s))
 
-type Read = { read(): Resume<string> }
+type Read = { read(): Resume<never, string> }
 const read = op<Read>(c => c.read())
 
 const main = co(function* () {
@@ -17,10 +17,10 @@ const main = co(function* () {
 })
 
 const capabilities = {
-  print: (s: string): Resume<void> =>
+  print: (s: string): Resume<never, void> =>
     resumeNow(void process.stdout.write(s)),
 
-  read: (): Resume<string> =>
+  read: (): Resume<never, string> =>
     resumeLater(k => {
       const handler = (s: string): void => {
         readline.close()

--- a/examples/fp-to-the-max-1.ts
+++ b/examples/fp-to-the-max-1.ts
@@ -9,12 +9,12 @@ import { createInterface } from 'readline'
 // -------------------------------------------------------------------
 // Capabilities the game will need
 
-type Print = { print(s: string): Resume<void> }
+type Print = { print(s: string): Resume<never, void> }
 const print = (s: string) => op<Print>(c => c.print(s))
 
 const println = (s: string) => print(`${s}\n`)
 
-type Read = { read(): Resume<string> }
+type Read = { read(): Resume<never, string> }
 const read = op<Read>(c => c.read())
 
 const ask = co(function* (prompt: string) {
@@ -22,7 +22,7 @@ const ask = co(function* (prompt: string) {
   return yield* read
 })
 
-type RandomInt = { randomInt(min: number, max: number): Resume<number> }
+type RandomInt = { randomInt(min: number, max: number): Resume<never, number> }
 const randomInt = (min: number, max: number) => op<RandomInt>(c => c.randomInt(min, max))
 
 // -------------------------------------------------------------------
@@ -63,7 +63,7 @@ const play = co(function* (name: string, min: number, max: number) {
 const checkContinue = co(function* (name: string) {
   while(true) {
     const answer = yield* ask(`Do you want to continue, ${name}? (y or n) `)
-  
+
     switch (answer.toLowerCase()) {
       case 'y': return true
       case 'n': return false
@@ -94,16 +94,16 @@ const capabilities = {
   min: 1,
   max: 5,
 
-  delay: (ms: number): Resume<void> =>
+  delay: (ms: number): Resume<never, void> =>
     resumeLater(k => {
       const t = setTimeout(k, ms)
       return () => clearTimeout(t)
-    }), 
+    }),
 
-  print: (s: string): Resume<void> =>
+  print: (s: string): Resume<never, void> =>
     resumeNow(void process.stdout.write(s)),
 
-  read: (): Resume<string> =>
+  read: (): Resume<never, string> =>
     resumeLater(k => {
       const readline = createInterface({ input: process.stdin })
         .once('line', s => {
@@ -113,7 +113,7 @@ const capabilities = {
       return () => readline.removeListener('line', k).close()
     }),
 
-  randomInt: (min: number, max: number): Resume<number> =>
+  randomInt: (min: number, max: number): Resume<never, number> =>
     resumeNow(Math.floor(min + (Math.random() * (max - min))))
 }
 

--- a/examples/fp-to-the-max-1.ts
+++ b/examples/fp-to-the-max-1.ts
@@ -78,7 +78,7 @@ const checkContinue = co(function* (name: string) {
 const main = co(function* () {
   const name = yield* ask('What is your name? ')
   yield* println(`Hello, ${name} welcome to the game!`)
-  // yield* delay(1000)
+  yield* delay(1000)
 
   do {
     yield* play(name)

--- a/src/array.ts
+++ b/src/array.ts
@@ -36,7 +36,7 @@ export const race = <Computations extends readonly Computation<any, any, any>[]>
     const cancels = cs.map((computation: Computations[number]) =>
       runResume(runComputation(computation)(c) as any, (s: Step<never, AnyResult<Computations>>) => {
         cancelAll()
-        return k({ done: false, value: s.value })
+        return k(s)
       }))
 
     const cancelAll = () => cancels.forEach(c => c())

--- a/src/array.ts
+++ b/src/array.ts
@@ -1,5 +1,5 @@
 import { Computation, Yield, Next, Return, op, runComputation } from './computation'
-import { Capabilities, Env, runResume, resume, uncancelable } from './env'
+import { Capabilities, Env, runResume, resume, uncancelable, Step } from './env'
 
 // Arrays and tuples of computations
 // Strongly-typed variadic operations support homogeneous arrays as well as
@@ -15,15 +15,15 @@ export type AnyResult<C extends readonly Computation<any, any, any>[]> = Return<
 type Writeable<T> = { -readonly [P in keyof T]: T[P] }
 
 // Turn a list of computations into a computation of a list
-export const zip = <Computations extends readonly Computation<any, any, any>[]>(...cs: Computations): Computation<Env<AllCapabilities<Computations>, AllResult<Computations>>, AllResult<Computations>, AllNexts<Computations>> =>
-  op((c: AllCapabilities<Computations>) => resume<AllResult<Computations>>(k => {
+export const zip = <Computations extends readonly Computation<any, any, any>[]>(...cs: Computations): Computation<Env<AllCapabilities<Computations>, never, AllResult<Computations>>, AllResult<Computations>, AllNexts<Computations>> =>
+  op((c: AllCapabilities<Computations>) => resume<never, AllResult<Computations>>(k => {
     let remaining = cs.length
     const results = Array(remaining) as Writeable<AllResult<Computations>>
 
     const cancels = cs.map((computation: Computations[typeof i], i) =>
-      runResume(runComputation(computation)(c), (x: AnyResult<Computations>) => {
-        results[i] = x
-        return --remaining === 0 ? k(results) : uncancelable
+      runResume(runComputation(computation)(c) as any, (s: Step<never, AnyResult<Computations>>) => {
+        results[i] = s.value
+        return --remaining === 0 ? k({ done: false, value: results }) : uncancelable
       }))
 
     return () => cancels.forEach(c => c())
@@ -31,12 +31,12 @@ export const zip = <Computations extends readonly Computation<any, any, any>[]>(
 
 // Return computation equivalent to the input computation that produces the earliest result
 // TODO: Consider requiring the input computations to be Async
-export const race = <Computations extends readonly Computation<any, any, any>[]>(...cs: Computations): Computation<Env<AllCapabilities<Computations>, AnyResult<Computations>>, AnyResult<Computations>, any> =>
-  op((c: AllCapabilities<Computations>) => resume<AnyResult<Computations>>(k => {
+export const race = <Computations extends readonly Computation<any, any, any>[]>(...cs: Computations): Computation<Env<AllCapabilities<Computations>, never, AnyResult<Computations>>, AnyResult<Computations>, any> =>
+  op((c: AllCapabilities<Computations>) => resume<never, AnyResult<Computations>>(k => {
     const cancels = cs.map((computation: Computations[number]) =>
-      runResume(runComputation(computation)(c), (x: AnyResult<Computations>) => {
+      runResume(runComputation(computation)(c) as any, (s: Step<never, AnyResult<Computations>>) => {
         cancelAll()
-        return k(x)
+        return k({ done: false, value: s.value })
       }))
 
     const cancelAll = () => cancels.forEach(c => c())

--- a/src/computation.ts
+++ b/src/computation.ts
@@ -1,4 +1,8 @@
+<<<<<<< HEAD
 import { Env, Capabilities, chainEnv, pureEnv, resumeNow, Resume, Use, Embed, resumeLater, runResume, chainResume } from './env'
+=======
+import { Env, Capabilities, chainEnv, pureEnv, resumeNow, Resume, Use, Embed, resume, uncancelable, runResume, chainResume } from './env'
+>>>>>>> WIP: Refactor runComputation to deal with Resume directly, instead of chainEnv
 
 // A Computation is a sequence of effects, each of which requires a set
 // of capabilities. Between those effects, there can be any number of

--- a/src/computation.ts
+++ b/src/computation.ts
@@ -17,12 +17,8 @@ export type Yield<C> = C extends Computation<infer Y, any, any> ? Y : never
 export type Return<C> = C extends Computation<any, infer R, any> ? R : never
 export type Next<C> = C extends Computation<any, any, infer N> ? N : never
 
-type Answer<C> = {
-  [K in keyof C]: C[K] extends (...a: readonly any[]) => Resume<any, infer A> ? A : never
-}[keyof C]
-
 type Result<C> = {
-  [K in keyof C]: C[K] extends (...a: readonly any[]) => Resume<infer R, any> ? R : never
+  [K in keyof C]: C[K] extends (...a: readonly any[]) => Resume<any, infer A> ? A : never
 }[keyof C]
 
 // Create a Computation from an Env-yielding generator
@@ -34,7 +30,7 @@ export const co = <A extends readonly any[], Y, R, N>(f: (...args: A) => Generat
   }) as Computation<Y, R, N>
 
 // Create a Computation from an Env
-export const op = <C, A = Answer<C>, R = never>(env: Env<C, R, A>): Computation<Env<C, R, A>, A, A> => ({
+export const op = <C, A = Result<C>, R = never>(env: Env<C, R, A>): Computation<Env<C, R, A>, A, A> => ({
   *[Symbol.iterator](): Iterator<Env<C, R, A>, A, A> { return yield env }
 }) as Computation<Env<C, R, A>, A, A>
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -3,67 +3,71 @@
 // locking in the answer types to Cancel, Cancel.  I haven't
 // figured out a nice way that doesn't cause type issues when
 // mixing sync effects and async effects which require cancelability.
-export type Env<C, A> = (c: C) => Resume<A>
+export type Env<C, R, A> = (c: C) => Resume<R, A>
 
 // An Env that requires no capabilities, and thus can be run *forall*
 // environments.  Thus, Pure is fully parametric in its capabilities.
-export interface Pure<A> {
-  <C>(c: C): Resume<A>
+export interface Pure<R, A> {
+  <C>(c: C): Resume<R, A>
 }
 
 // Satisfy some or all of an Env's requirements, at the type level.
 // Importantly, this evaluates to Pure when all of E's capabilities
 // have been satisfied.
 export type Use<E, CP> =
-  E extends Pure<any>
+  E extends Pure<any, any>
   ? E
-  : E extends Env<infer C, infer A>
-    ? CP extends C ? Pure<A>
-    : C extends CP ? Env<Omit<C, keyof CP>, A>
+  : E extends Env<infer C, infer R, infer A>
+    ? CP extends C ? Pure<R, A>
+    : C extends CP ? Env<Omit<C, keyof CP>, R, A>
   : E : E
 
 // Change the capabilities of an Env
 // Useful for changing the capabilities of Env unions
 // Embed<Env<C1, A> | Env<C2, B>, C3> = Env<C3, A> | Env<C3, B>
 export type Embed<E, C> =
-  E extends Env<any, infer A>
-  ? Env<C, A> : never
+  E extends Env<any, infer R, infer A>
+  ? Env<C, R, A> : never
 
 // Get the type of capabilities required by Envs
 export type Capabilities<E> = U2I<CapabilitiesOf<E>>
 type U2I<U> =
   (U extends any ? (k: U) => void : never) extends ((k: infer I) => void) ? I : never
-type CapabilitiesOf<E> = E extends Pure<any> ? never : E extends Env<infer C, any> ? C : never
+type CapabilitiesOf<E> = E extends Pure<any, any> ? never : E extends Env<infer C, any, any> ? C : never
 
-export const pureEnv = <A>(a: A): Pure<A> =>
-  <C>(_: C) => resumeNow(a)
+// export const pureEnv = <A>(a: A): Pure<A> =>
+//   <C>(_: C) => resumeNow(a)
 
-export const chainEnv = <C1, C2, A, B> (e: Env<C1, A>, f: (a: A) => Env<C2, B>): Env<C1 & C2, B> =>
-  c12 => chainResume(e(c12), a => f(a)(c12))
+// export const chainEnv = <C1, C2, A, B> (e: Env<C1, A>, f: (a: A) => Env<C2, B>): Env<C1 & C2, B> =>
+//   c12 => chainResume(e(c12), a => f(a)(c12))
 
-export type Resume<A> =
-  | { now: true, value: A }
-  | { now: false, run: (k: (a: A) => Cancel) => Cancel }
+export type Step<R, A> =
+  | { readonly done: true, readonly value: R }
+  | { readonly done: false, readonly value: A }
+
+export type Resume<R, A> =
+  | { now: true, value: Step<R, A> }
+  | { now: false, run: (k: (s: Step<R, A>) => Cancel) => Cancel }
 
 export type Cancel = () => void
 
 export const uncancelable = () => {}
 
-export const resumeNow = <A>(value: A): Resume<A> =>
-  ({ now: true, value })
+export const resumeNow = <R, A>(value: A): Resume<R, A> =>
+  ({ now: true, value: { done: false, value } })
 
-export const resume = <A>(run: (k: (a: A) => Cancel) => Cancel): Resume<A> =>
+export const done = <R, A>(value: R): Resume<R, A> =>
+  ({ now: true, value: { done: true, value } })
+
+export const resume = <R, A>(run: (k: (s: Step<R, A>) => Cancel) => Cancel): Resume<R, A> =>
   ({ now: false, run })
 
-export const resumeLater = <A> (run: (k: (a: A) => void) => Cancel): Resume<A> =>
+export const resumeLater = <R, A> (run: (k: (a: A) => void) => Cancel): Resume<R, A> =>
   resume(k => {
     let cancel = uncancelable
-    cancel = run(a => (cancel = k(a)))
+    cancel = run(a => (cancel = k({ done: false, value: a })))
     return () => cancel()
   })
 
-export const runResume = <A> (ra: Resume<A>, k: (a: A) => Cancel): Cancel =>
+export const runResume = <R, A> (ra: Resume<R, A>, k: (s: Step<R, A>) => Cancel): Cancel =>
   ra.now ? k(ra.value) : ra.run(k)
-
-export const chainResume = <A, B>(ra: Resume<A>, f: (a: A) => Resume<B>): Resume<B> =>
-  ra.now ? f(ra.value) : resume(k => ra.run(a => runResume(f(a), k)))

--- a/src/env.ts
+++ b/src/env.ts
@@ -7,18 +7,18 @@ export type Env<C, R, A> = (c: C) => Resume<R, A>
 
 // An Env that requires no capabilities, and thus can be run *forall*
 // environments.  Thus, Pure is fully parametric in its capabilities.
-export interface Pure<R, A> {
-  <C>(c: C): Resume<R, A>
+export interface Pure<A> {
+  <C, R>(c: C): Resume<R, A>
 }
 
 // Satisfy some or all of an Env's requirements, at the type level.
 // Importantly, this evaluates to Pure when all of E's capabilities
 // have been satisfied.
 export type Use<E, CP> =
-  E extends Pure<any, any>
+  E extends Pure<any>
   ? E
   : E extends Env<infer C, infer R, infer A>
-    ? CP extends C ? Pure<R, A>
+    ? CP extends C ? Pure<A>
     : C extends CP ? Env<Omit<C, keyof CP>, R, A>
   : E : E
 
@@ -33,10 +33,10 @@ export type Embed<E, C> =
 export type Capabilities<E> = U2I<CapabilitiesOf<E>>
 type U2I<U> =
   (U extends any ? (k: U) => void : never) extends ((k: infer I) => void) ? I : never
-type CapabilitiesOf<E> = E extends Pure<any, any> ? never : E extends Env<infer C, any, any> ? C : never
+type CapabilitiesOf<E> = E extends Pure<any> ? never : E extends Env<infer C, any, any> ? C : never
 
 // export const pureEnv = <A>(a: A): Pure<A> =>
-//   <C>(_: C) => resumeNow(a)
+//   <C, R>(_: C) => resumeNow<R, A>(a)
 
 // export const chainEnv = <C1, C2, A, B> (e: Env<C1, A>, f: (a: A) => Env<C2, B>): Env<C1 & C2, B> =>
 //   c12 => chainResume(e(c12), a => f(a)(c12))

--- a/src/fail.ts
+++ b/src/fail.ts
@@ -1,0 +1,31 @@
+import { op, Computation, use } from './computation'
+import { Resume, Env, Capabilities, resume } from './env'
+import { unsafeRun } from './run'
+
+export type Remove<E extends Computation<any, any, any>, C, M extends string> =
+  E extends Computation<infer Y, infer R, infer N> ? AssertExtends<Capabilities<Y>, C, R, N, M> : never
+
+type AssertExtends<Sub, Sup, R, N, M> = Sub extends Sup
+  ? Computation<Env<Omit<Sub, keyof Sup>, R, N>, R, N>
+  : { capabilities: Sub, required: Sup, error: M }
+
+export type Raise<T extends string | symbol, E> = Record<T, (e: E) => Resume<never, never>>
+export const raise = <T extends string | symbol, E>(t: T, e: E) => op<Raise<T, E>, void>(c => c[t](e))
+
+const failSymbol = Symbol('Fail')
+
+export interface Fail extends Raise<typeof failSymbol, void> { }
+export const fail = op<Fail, void>(c => c[failSymbol]())
+
+type AttemptError = 'attempt() may only be applied to Computations with the Fail effect'
+export const attempt = <Y extends Env<any, any, any>, R, N>(co: Computation<Y, R, N>): Remove<Computation<Y, R | undefined, N>, Fail, AttemptError> =>
+  op(c => resume(k => {
+    const cancel = unsafeRun(use(co, {
+      ...c as any,
+      [failSymbol]() {
+        cancel()
+        return resume(_ => k({ done: false, value: undefined }))
+      }
+    }), k)
+    return cancel
+  })) as Remove<Computation<Y, R | undefined, N>, Fail, AttemptError>

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,5 +1,5 @@
 import { Cancel, runResume, Pure, uncancelable, Step } from './env'
 import { Computation, runComputation } from './computation'
 
-export const unsafeRun = <Y extends Pure<any>, R, N>(c: Computation<Y, R, N>, f: (s: Step<R, never>) => Cancel = () => uncancelable): Cancel =>
+export const unsafeRun = <Y extends Pure<any>, R, N>(c: Computation<Y, R, N>, f: (s: Step<R, R>) => Cancel = () => uncancelable): Cancel =>
   runResume(runComputation(c)({} as never), f)

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,5 +1,5 @@
-import { Cancel, runResume, Pure, uncancelable, Step } from './env'
+import { Cancel, runResume, Pure, uncancelable, Step, Capabilities } from './env'
 import { Computation, runComputation } from './computation'
 
 export const unsafeRun = <Y extends Pure<any>, R, N>(c: Computation<Y, R, N>, f: (s: Step<R, R>) => Cancel = () => uncancelable): Cancel =>
-  runResume(runComputation(c)({} as never), f)
+  runResume(runComputation(c, {} as Capabilities<Y>), f)

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,5 +1,5 @@
 import { Cancel, runResume, Pure, uncancelable, Step } from './env'
 import { Computation, runComputation } from './computation'
 
-export const unsafeRun = <Y extends Pure<R, any>, R, N>(c: Computation<Y, R, N>, f: (s: Step<R, never>) => Cancel = () => uncancelable): Cancel =>
+export const unsafeRun = <Y extends Pure<any>, R, N>(c: Computation<Y, R, N>, f: (s: Step<R, never>) => Cancel = () => uncancelable): Cancel =>
   runResume(runComputation(c)({} as never), f)

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,6 +1,5 @@
-import { Cancel, runResume, Pure, uncancelable } from './env'
+import { Cancel, runResume, Pure, uncancelable, Step } from './env'
 import { Computation, runComputation } from './computation'
 
-export const unsafeRun = <Y extends Pure<any>, R, N>(c: Computation<Y, R, N>, f: (r: R) => Cancel = () => uncancelable): Cancel =>
+export const unsafeRun = <Y extends Pure<R, any>, R, N>(c: Computation<Y, R, N>, f: (s: Step<R, never>) => Cancel = () => uncancelable): Cancel =>
   runResume(runComputation(c)({} as never), f)
-  

--- a/src/timer.ts
+++ b/src/timer.ts
@@ -2,7 +2,7 @@ import { Resume } from './env'
 import { op, Computation, co } from './computation'
 import { race } from './array'
 
-export type Delay = { delay(ms: number): Resume<void> }
+export type Delay = { delay(ms: number): Resume<never, void> }
 export const delay = (ms: number) => op<Delay>(c => c.delay(ms))
 
 export const timeout = co(function* <Y, R, N>(ms: number, c: Computation<Y, R, N>) {

--- a/src/timer.ts
+++ b/src/timer.ts
@@ -10,7 +10,7 @@ export const timeout = co(function* <Y, R, N>(ms: number, c: Computation<Y, R, N
   return yield* race(c, delayFail(ms))
 })
 
-const delayFail = co(function* (ms: number): Generator<Env<Delay, never, void> | Env<Fail, never, void>, never, void> {
+const delayFail = co(function* (ms: number): Generator<Env<Delay, never, void> | Env<Fail, unknown, unknown>, never, void> {
   yield* delay(ms)
   return (yield* fail) as never
 })

--- a/src/timer.ts
+++ b/src/timer.ts
@@ -1,10 +1,16 @@
-import { Resume } from './env'
+import { Resume, Env } from './env'
 import { op, Computation, co } from './computation'
 import { race } from './array'
+import { fail, Fail } from './fail'
 
 export type Delay = { delay(ms: number): Resume<never, void> }
 export const delay = (ms: number) => op<Delay>(c => c.delay(ms))
 
 export const timeout = co(function* <Y, R, N>(ms: number, c: Computation<Y, R, N>) {
-  return yield* race(c, delay(ms))
+  return yield* race(c, delayFail(ms))
+})
+
+const delayFail = co(function* (ms: number): Generator<Env<Delay, never, void> | Env<Fail, never, void>, never, void> {
+  yield* delay(ms)
+  return (yield* fail) as never
 })


### PR DESCRIPTION
Just hacking right now.  The types got a lot messier, especially around Resume, but that can be cleaned up with some type aliases and helper functions.

Experimenting with a couple things:

1. Direct support for non-total effects, such as producing no result or failing with an error.
2. Stack safety for synchronous effects