### PR TITLE
Make runComputation stack safe for sync and async computations

### DIFF
--- a/examples/echo-console.ts
+++ b/examples/echo-console.ts
@@ -26,7 +26,7 @@ const capabilities = {
         readline.close()
         k(s)
       }
-      const readline = createInterface({ input: process.stdin }).once('line', handler)  
+      const readline = createInterface({ input: process.stdin }).once('line', handler)
       return () => readline.removeListener('line', handler).close()
     })
 }


### PR DESCRIPTION
Use stack safe while loop for sync computations.  This allows sync computations to loop forever without blowing up the stack.

I don't care about performance right now, but this probably also improves performance for sync computations, much as it did with [forgefx](https://github.com/briancavalier/forgefx).