### PR TITLE
Add default async env

### DIFF
--- a/examples/echo-console.ts
+++ b/examples/echo-console.ts
@@ -1,7 +1,7 @@
 import { EOL } from 'os'
 import { createInterface } from 'readline'
 
-import { Async, async, defaultAsync, doFx, Fx, get, Pure, pure, resume, runFx } from '../src'
+import { Async, async, defaultAsyncEnv, doFx, Fx, get, Pure, pure, runFx } from '../src'
 
 type Print = { print(s: string): Pure<void> }
 
@@ -17,7 +17,7 @@ const main = doFx(function* () {
 })
 
 const capabilities = {
-  ...defaultAsync,
+  ...defaultAsyncEnv,
 
   print: (s: string): Pure<void> =>
     pure(void process.stdout.write(s)),

--- a/examples/echo-console.ts
+++ b/examples/echo-console.ts
@@ -1,9 +1,9 @@
 import { EOL } from 'os'
 import { createInterface } from 'readline'
 
-import { Async, async, defaultAsyncEnv, doFx, Fx, get, Pure, pure, runFx } from '../src'
+import { Async, async, defaultAsyncEnv, doFx, Fx, get, None, pure, runFx } from '../src'
 
-type Print = { print(s: string): Pure<void> }
+type Print = { print(s: string): Fx<None, void> }
 
 type Read = { read: Fx<Async, string> }
 
@@ -19,7 +19,7 @@ const main = doFx(function* () {
 const capabilities = {
   ...defaultAsyncEnv,
 
-  print: (s: string): Pure<void> =>
+  print: (s: string): Fx<None, void> =>
     pure(void process.stdout.write(s)),
 
   read: async<string>(k => {

--- a/examples/echo-console.ts
+++ b/examples/echo-console.ts
@@ -1,7 +1,7 @@
 import { EOL } from 'os'
 import { createInterface } from 'readline'
 
-import { Async, async, doFx, Fx, get, Pure, pure, resume, runFx } from '../src'
+import { Async, async, defaultAsync, doFx, Fx, get, Pure, pure, resume, runFx } from '../src'
 
 type Print = { print(s: string): Pure<void> }
 
@@ -17,7 +17,7 @@ const main = doFx(function* () {
 })
 
 const capabilities = {
-  async: resume,
+  ...defaultAsync,
 
   print: (s: string): Pure<void> =>
     pure(void process.stdout.write(s)),

--- a/examples/fp-to-the-max-1.ts
+++ b/examples/fp-to-the-max-1.ts
@@ -2,7 +2,7 @@ import { EOL } from 'os'
 import { createInterface } from 'readline'
 
 import {
-  Async, async, attempt, defaultAsync, doFx, Fx, get, Pure, pure, runFx, timeout
+  Async, async, attempt, defaultAsyncEnv, doFx, Fx, get, Pure, pure, runFx, timeout
 } from '../src'
 
 // -------------------------------------------------------------------
@@ -105,7 +105,7 @@ const capabilities = {
   min: 1,
   max: 5,
 
-  ...defaultAsync,
+  ...defaultAsyncEnv,
 
   print: (s: string): Pure<void> =>
     pure(void process.stdout.write(s)),

--- a/examples/fp-to-the-max-1.ts
+++ b/examples/fp-to-the-max-1.ts
@@ -2,7 +2,7 @@ import { EOL } from 'os'
 import { createInterface } from 'readline'
 
 import {
-  Async, async, attempt, defaultAsyncEnv, doFx, Fx, get, Pure, pure, runFx, timeout
+  Async, async, attempt, defaultAsyncEnv, doFx, Fx, get, None, pure, runFx, timeout
 } from '../src'
 
 // -------------------------------------------------------------------
@@ -12,11 +12,11 @@ import {
 // -------------------------------------------------------------------
 // Capabilities the game will need
 
-type Print = { print(s: string): Pure<void> }
+type Print = { print(s: string): Fx<None, void> }
 
 type Read = { read: Fx<Async, string> }
 
-type RandomInt = { randomInt(min: number, max: number): Pure<number> }
+type RandomInt = { randomInt(min: number, max: number): Fx<None, number> }
 
 // -------------------------------------------------------------------
 // Basic operations that use the capabilites
@@ -107,7 +107,7 @@ const capabilities = {
 
   ...defaultAsyncEnv,
 
-  print: (s: string): Pure<void> =>
+  print: (s: string): Fx<None, void> =>
     pure(void process.stdout.write(s)),
 
   read: async<string>(k => {
@@ -119,7 +119,7 @@ const capabilities = {
     return () => readline.removeListener('line', k).close()
   }),
 
-  randomInt: (min: number, max: number): Pure<number> =>
+  randomInt: (min: number, max: number): Fx<None, number> =>
     pure(Math.floor(min + (Math.random() * (max - min))))
 }
 

--- a/examples/fp-to-the-max-1.ts
+++ b/examples/fp-to-the-max-1.ts
@@ -1,7 +1,9 @@
 import { EOL } from 'os'
 import { createInterface } from 'readline'
 
-import { Async, async, attempt, doFx, Fx, get, Pure, pure, resume, runFx, timeout } from '../src'
+import {
+  Async, async, attempt, defaultAsync, doFx, Fx, get, Pure, pure, runFx, timeout
+} from '../src'
 
 // -------------------------------------------------------------------
 // The number guessing game example from
@@ -14,7 +16,7 @@ type Print = { print(s: string): Pure<void> }
 
 type Read = { read: Fx<Async, string> }
 
-type RandomInt = { randomInt(min: number, max: number): Fx<unknown, number> }
+type RandomInt = { randomInt(min: number, max: number): Pure<number> }
 
 // -------------------------------------------------------------------
 // Basic operations that use the capabilites
@@ -103,12 +105,7 @@ const capabilities = {
   min: 1,
   max: 5,
 
-  async: resume,
-
-  delay: (ms: number): Fx<Async, void> => async(k => {
-    const t = setTimeout(k, ms)
-    return () => clearTimeout(t)
-  }),
+  ...defaultAsync,
 
   print: (s: string): Pure<void> =>
     pure(void process.stdout.write(s)),
@@ -122,7 +119,7 @@ const capabilities = {
     return () => readline.removeListener('line', k).close()
   }),
 
-  randomInt: (min: number, max: number): Fx<unknown, number> =>
+  randomInt: (min: number, max: number): Pure<number> =>
     pure(Math.floor(min + (Math.random() * (max - min))))
 }
 

--- a/examples/lambda-pets/env.ts
+++ b/examples/lambda-pets/env.ts
@@ -1,11 +1,11 @@
-import { defaultAsync, Pure, pure } from '../../src'
-import { httpImpl } from './src/infrastructure/http'
+import { defaultAsyncEnv, Pure, pure } from '../../src'
+import { httpEnv } from './src/infrastructure/http'
 import { getLocation } from './src/infrastructure/ipstack'
 import { getPets } from './src/infrastructure/petfinder'
 
 export const env = {
-  ...defaultAsync,
-  ...httpImpl,
+  ...defaultAsyncEnv,
+  ...httpEnv,
 
   radiusMiles: Number(process.env.DEFAULT_RADIUS_MILES) || 10,
 

--- a/examples/lambda-pets/env.ts
+++ b/examples/lambda-pets/env.ts
@@ -1,10 +1,11 @@
-import { Async, async, Fx, Pure, pure, resume } from '../../src'
+import { defaultAsync, Pure, pure } from '../../src'
 import { httpImpl } from './src/infrastructure/http'
 import { getLocation } from './src/infrastructure/ipstack'
 import { getPets } from './src/infrastructure/petfinder'
 
 export const env = {
-  async: resume,
+  ...defaultAsync,
+  ...httpImpl,
 
   radiusMiles: Number(process.env.DEFAULT_RADIUS_MILES) || 10,
 
@@ -22,14 +23,7 @@ export const env = {
 
   log: (s: string): Pure<void> => pure(console.log(Date.now(), s)),
 
-  delay: (ms: number): Fx<Async, void> => async(k => {
-    const t = setTimeout(k, ms)
-    return () => clearTimeout(t)
-  }),
-
   getLocation,
 
-  getPets,
-
-  ...httpImpl
+  getPets
 }

--- a/examples/lambda-pets/env.ts
+++ b/examples/lambda-pets/env.ts
@@ -1,4 +1,4 @@
-import { defaultAsyncEnv, Pure, pure } from '../../src'
+import { defaultAsyncEnv, Fx, None, pure } from '../../src'
 import { httpEnv } from './src/infrastructure/http'
 import { getLocation } from './src/infrastructure/ipstack'
 import { getPets } from './src/infrastructure/petfinder'
@@ -21,7 +21,7 @@ export const env = {
     client_secret: process.env.PETFINDER_SECRET || ''
   },
 
-  log: (s: string): Pure<void> => pure(console.log(Date.now(), s)),
+  log: (s: string): Fx<None, void> => pure(console.log(Date.now(), s)),
 
   getLocation,
 

--- a/examples/lambda-pets/src/application/pets.ts
+++ b/examples/lambda-pets/src/application/pets.ts
@@ -1,4 +1,4 @@
-import { attempt, catchAll, doFx, get, pure, Pure, timeout } from '../../../../src'
+import { attempt, catchAll, doFx, Fx, get, None, pure, timeout } from '../../../../src'
 import { defaultLocation } from '../domain/model'
 import { getLocation } from '../infrastructure/ipstack'
 import { getPets } from '../infrastructure/petfinder'
@@ -7,7 +7,7 @@ import { renderError, renderPets } from './render'
 export type PetsEnv = {
   getPets: typeof getPets,
   getLocation: typeof getLocation
-  log: (s: string) => Pure<void>
+  log: (s: string) => Fx<None, void>
 
   radiusMiles: number,
   locationTimeout: number,

--- a/examples/lambda-pets/src/infrastructure/http.ts
+++ b/examples/lambda-pets/src/infrastructure/http.ts
@@ -45,7 +45,7 @@ const interpretFailure = (url: string, result: Response): Error =>
     ? new Error(`Request failed ${result.response.statusCode}: ${url} ${result.body}`)
     : result.error
 
-export const httpImpl: Http<Async, Request, Response> = {
+export const httpEnv: Http<Async, Request, Response> = {
   http: (r: Request): Fx<Async, Response> =>
     async(k => {
       const options = { method: r.method, ...parseUrl(r.url), headers: r.headers }

--- a/src/async.ts
+++ b/src/async.ts
@@ -12,6 +12,15 @@ export type Async = { async<A>(run: AsyncTask<A>): Resume<A> }
 
 export const async = <A>(run: AsyncTask<A>): Fx<Async, A> => op(c => c.async(run))
 
+export const defaultAsync: Async & Delay = {
+  async: resume,
+  delay: (ms: number): Fx<Async, void> =>
+    async<void>(k => {
+      const t = setTimeout(k, ms)
+      return () => clearTimeout(t)
+    })
+}
+
 export type Delay = { delay(ms: number): Fx<Async, void> }
 
 export const delay = (ms: number): Fx<Delay & Async, void> => doFx(function* () {

--- a/src/async.ts
+++ b/src/async.ts
@@ -12,7 +12,7 @@ export type Async = { async<A>(run: AsyncTask<A>): Resume<A> }
 
 export const async = <A>(run: AsyncTask<A>): Fx<Async, A> => op(c => c.async(run))
 
-export const defaultAsync: Async & Delay = {
+export const defaultAsyncEnv: Async & Delay = {
   async: resume,
   delay: (ms: number): Fx<Async, void> =>
     async<void>(k => {

--- a/src/fx.ts
+++ b/src/fx.ts
@@ -11,7 +11,7 @@ import { Cancel, Env, Intersect, Resume, resume, resumeNow, runResume, uncancela
 export interface Fx<C, A> extends FxIterable<Env<C, unknown>, A> { }
 
 // An Fx that requires no particular capabilities and produces no effects
-export interface Pure<A> extends Fx<unknown, A> { }
+export type None = unknown
 
 export interface FxIterable<Y, R> {
   'fx-ts/Fx': never
@@ -40,9 +40,9 @@ export const op = <C, A>(env: Env<C, A>): Fx<C, A> => ({
 
 // Create an Fx that returns A, with no effects and requires
 // no particular environment
-export const pure = <A>(a: A): Pure<A> => ({
+export const pure = <A>(a: A): Fx<None, A> => ({
   *[Symbol.iterator](): Iterator<never, A, A> { return a }
-}) as Pure<A>
+}) as Fx<None, A>
 
 // Run an Fx by providing its remaining capability requirements
 export const runFx = <C, A>(fx: Fx<C, A>, c: C, k: (r: A) => Cancel = () => uncancelable): Cancel =>


### PR DESCRIPTION
Add an importable default async env that can be spread into the top level env to provide some useful default implementations of base effects.