### PR TITLE
Allow doFx to request a specific environment

### DIFF
--- a/examples/echo-console.ts
+++ b/examples/echo-console.ts
@@ -7,8 +7,7 @@ type Print = { print(s: string): Fx<None, void> }
 
 type Read = { read: Fx<Async, string> }
 
-const main = doFx(function* () {
-  const { print, read } = yield* get<Print & Read>()
+const main = doFx(function* ({ print, read }: Print & Read) {
   while (true) {
     yield* print('> ')
     const s = yield* read

--- a/examples/fp-to-the-max-1.ts
+++ b/examples/fp-to-the-max-1.ts
@@ -21,19 +21,16 @@ type RandomInt = { randomInt(min: number, max: number): Fx<None, number> }
 // -------------------------------------------------------------------
 // Basic operations that use the capabilites
 
-const println = (s: string): Fx<Print, void> => doFx(function* () {
-  const { print } = yield* get<Print>()
+const println = (s: string): Fx<Print, void> => doFx(function* ({ print }: Print) {
   return yield* print(`${s}${EOL}`)
 })
 
-const ask = (prompt: string): Fx<Print & Read & Async, string> => doFx(function* () {
-  const { print, read } = yield* get<Print & Read>()
+const ask = (prompt: string): Fx<Print & Read & Async, string> => doFx(function* ({ print, read }: Print & Read) {
   yield* print(prompt)
   return yield* read
 })
 
-const randomInt = (min: number, max: number): Fx<RandomInt, number> => doFx(function* () {
-  const { randomInt } = yield* get<RandomInt>()
+const randomInt = (min: number, max: number): Fx<RandomInt, number> => doFx(function* ({ randomInt }: RandomInt) {
   return yield* randomInt(min, max)
 })
 
@@ -84,11 +81,9 @@ const checkContinue = (name: string) => doFx(function* () {
 })
 
 // Main game loop. Play round after round until the user chooses to quit
-const main = doFx(function* () {
+const main = doFx(function* ({ min, max }: GameConfig) {
   const name = yield* ask('What is your name? ')
   yield* println(`Hello, ${name} welcome to the game!`)
-
-  const { min, max } = yield* get<GameConfig>()
 
   do {
     yield* play(name, min, max)

--- a/examples/lambda-pets/src/application/pets.ts
+++ b/examples/lambda-pets/src/application/pets.ts
@@ -1,4 +1,4 @@
-import { attempt, catchAll, doFx, Fx, get, None, pure, timeout } from '../../../../src'
+import { attempt, catchAll, doFx, Fx, None, pure, timeout } from '../../../../src'
 import { defaultLocation } from '../domain/model'
 import { getLocation } from '../infrastructure/ipstack'
 import { getPets } from '../infrastructure/petfinder'
@@ -23,9 +23,7 @@ export const getAdoptablePetsNear = (ip: string) => doFx(function* () {
     : { statusCode: 200, body: renderPets(petsOrError), headers: HEADERS }
 })
 
-export const tryGetAdoptablePetsNear = (ip: string) => doFx(function* () {
-  const { radiusMiles, locationTimeout, petsTimeout, log, getLocation, getPets } = yield* get<PetsEnv>()
-
+export const tryGetAdoptablePetsNear = (ip: string) => doFx(function* ({ radiusMiles, locationTimeout, petsTimeout, log, getLocation, getPets }: PetsEnv) {
   const location = yield* catchAll(timeout(locationTimeout, getLocation(ip)), () => pure(defaultLocation))
 
   yield* log(`Geo location for ${ip}: ${location.latitude} ${location.longitude}`)

--- a/examples/lambda-pets/src/infrastructure/http.ts
+++ b/examples/lambda-pets/src/infrastructure/http.ts
@@ -2,7 +2,7 @@ import { IncomingMessage, request } from 'http'
 import { request as httpsRequest } from 'https'
 import { parse as parseUrl } from 'url'
 
-import { Async, async, doFx, fail, Fail, Fx, get } from '../../../../src'
+import { Async, async, doFx, fail, Fail, Fx } from '../../../../src'
 
 // Abstract Http capability interface
 export type Http<Effects, Req, Res> = { http(r: Req): Fx<Effects, Res> }
@@ -22,17 +22,17 @@ type Response =
 
 export type HttpEnv = Http<Async, Request, Response> & Async & Fail
 
-export const getJson = <R>(url: string, headers: { [name: string]: string } = {}): Fx<HttpEnv, R> => doFx(function* () {
-  const { http } = yield* get<Http<Async, Request, Response>>()
-  const result = yield* http({ method: 'GET', url, headers })
-  return yield* interpretResponse<R>(url, result)
-})
+export const getJson = <R>(url: string, headers: { [name: string]: string } = {}): Fx<HttpEnv, R> =>
+  doFx(function* ({ http }: Http<Async, Request, Response>) {
+    const result = yield* http({ method: 'GET', url, headers })
+    return yield* interpretResponse<R>(url, result)
+  })
 
-export const postJson = <A, R>(url: string, a: A, headers: { [name: string]: string } = {}): Fx<HttpEnv, R> => doFx(function* () {
-  const { http } = yield* get<Http<Async, Request, Response>>()
-  const result = yield* http({ method: 'POST', url, headers, body: JSON.stringify(a) })
-  return yield* interpretResponse<R>(url, result)
-})
+export const postJson = <A, R>(url: string, a: A, headers: { [name: string]: string } = {}): Fx<HttpEnv, R> =>
+  doFx(function* ({ http }: Http<Async, Request, Response>) {
+    const result = yield* http({ method: 'POST', url, headers, body: JSON.stringify(a) })
+    return yield* interpretResponse<R>(url, result)
+  })
 
 const interpretResponse = <R>(url: string, result: Response): Fx<Fail, R> => doFx(function* () {
   return result.type === 'Response' && result.response.statusCode === 200

--- a/examples/lambda-pets/src/infrastructure/ipstack.ts
+++ b/examples/lambda-pets/src/infrastructure/ipstack.ts
@@ -1,4 +1,4 @@
-import { doFx, fail, get } from '../../../../src'
+import { doFx, fail } from '../../../../src'
 import { GetLocation, Location } from '../domain/model'
 import { getJson, HttpEnv } from './http'
 
@@ -11,8 +11,7 @@ export type IpStackConfig = {
   ipstackKey: string
 }
 
-export const getLocation: GetLocation<HttpEnv & IpStackConfig> = (host: string) => doFx(function* () {
-  const { ipstackKey } = yield* get<IpStackConfig>()
+export const getLocation: GetLocation<HttpEnv & IpStackConfig> = (host: string) => doFx(function* ({ ipstackKey }: IpStackConfig) {
   const location = yield* getJson<Partial<Location>>(`http://api.ipstack.com/${host}?hostname=1&access_key=${ipstackKey}`)
   if (location.latitude == null || location.longitude == null) return yield* fail(new Error('Invalid location'))
   return location as Location

--- a/examples/lambda-pets/src/infrastructure/petfinder.ts
+++ b/examples/lambda-pets/src/infrastructure/petfinder.ts
@@ -1,4 +1,4 @@
-import { doFx, Fx, get } from '../../../../src'
+import { doFx, Fx } from '../../../../src'
 import { GeoLocation, GetPets, Pets } from '../domain/model'
 import { getJson, HttpEnv, postJson } from './http'
 
@@ -35,8 +35,7 @@ export type PetfinderConfig = {
   petfinderAuth: PetfinderAuth
 }
 
-export const getPets: GetPets<HttpEnv & PetfinderConfig> = (l: GeoLocation, radiusMiles: number): Fx<HttpEnv & PetfinderConfig, Pets> => doFx(function* () {
-  const { petfinderAuth } = yield* get<PetfinderConfig>()
+export const getPets: GetPets<HttpEnv & PetfinderConfig> = (l: GeoLocation, radiusMiles: number): Fx<HttpEnv & PetfinderConfig, Pets> => doFx(function* ({ petfinderAuth }: PetfinderConfig) {
   const token = yield* postJson<PetfinderAuth, PetfinderToken>('https://api.petfinder.com/v2/oauth2/token', petfinderAuth)
 
   const { animals } = yield* getJson<PetfinderPets>(`https://api.petfinder.com/v2/animals?location=${l.latitude},${l.longitude}&distance=${Math.ceil(radiusMiles)}`, {


### PR DESCRIPTION
This pattern had become ubiquitous:

```ts
const f = (...) => doFx(function* () {
  const { foo, bar } = get<Foo & Bar>()
  // do stuff with foo and bar
})
```

This PR allows doFx to request the environment that you would have requested with get:

```ts
const f = (...) => doFx(function* ({ foo, bar }: Foo & Bar) {
  // do stuff with foo and bar
})
```