### PR TITLE
Allow abstract Fx interfaces to omit their dependencies

### DIFF
--- a/examples/echo-console.ts
+++ b/examples/echo-console.ts
@@ -1,11 +1,11 @@
 import { EOL } from 'os'
 import { createInterface } from 'readline'
 
-import { Async, async, defaultEnv, doFx, Fx, runFx, sync, Sync } from '../src'
+import { async, defaultEnv, doFx, Fx, FxInterface, runFx, sync, Sync, use } from '../src'
 
-type Print = { print(s: string): Fx<Sync, void> }
+interface Print { print(s: string): FxInterface<void> }
 
-type Read = { read: Fx<Async, string> }
+interface Read { read: FxInterface<string> }
 
 const main = doFx(function* ({ print, read }: Print & Read) {
   while (true) {
@@ -31,4 +31,6 @@ const capabilities = {
   })
 }
 
-runFx(main, capabilities)
+const m = use(main, capabilities)
+
+runFx(m)

--- a/examples/fp-to-the-max-1.ts
+++ b/examples/fp-to-the-max-1.ts
@@ -1,7 +1,9 @@
 import { EOL } from 'os'
 import { createInterface } from 'readline'
 
-import { Async, async, attempt, defaultEnv, doFx, Fx, runFx, Sync, sync, timeout } from '../src'
+import {
+  Async, async, attempt, defaultEnv, doFx, Fx, runFx, Sync, sync, timeout, use
+} from '../src'
 
 // -------------------------------------------------------------------
 // The number guessing game example from
@@ -116,4 +118,4 @@ const capabilities = {
     sync(() => Math.floor(min + (Math.random() * (max - min))))
 }
 
-runFx(main, capabilities)
+runFx(use(main, capabilities))

--- a/src/array.ts
+++ b/src/array.ts
@@ -1,5 +1,5 @@
 import { Intersect, resume, uncancelable } from './env'
-import { Effects, Fx, op, Return, runFx } from './fx'
+import { Effects, Fx, op, Return, runFxWith } from './fx'
 
 export type AllEffects<Fxs extends readonly Fx<any, any>[]> = Intersect<Effects<Fxs[number]>>
 
@@ -16,7 +16,7 @@ export const zip = <Fxs extends readonly Fx<any, any>[]>(...fxs: Fxs): Fx<AllEff
     const results = Array(remaining) as Writeable<ZipResults<Fxs>>
 
     const cancels = fxs.map((fx: Fxs[typeof i], i) =>
-      runFx(fx, c, (x: AnyResult<Fxs>) => {
+      runFxWith(fx, c, (x: AnyResult<Fxs>) => {
         results[i] = x
         return --remaining === 0 ? k(results) : uncancelable
       }))

--- a/src/async.ts
+++ b/src/async.ts
@@ -2,7 +2,7 @@
 import { AllEffects, AnyResult } from './array'
 import { Cancel, Resume, resume } from './env'
 import { fail, Fail } from './fail'
-import { doFx, Fx, get, op, runFx } from './fx'
+import { doFx, Fx, get, op, runFxWith } from './fx'
 
 export type AsyncTask<A> = (k: (a: A) => Cancel) => Cancel
 
@@ -45,7 +45,7 @@ export const race = <C1 extends Async, C2 extends Async, A, B, Fxs extends reado
 const raceArray = <Fxs extends readonly Fx<any, any>[]>(fxs: Fxs): Fx<AllEffects<Fxs>, AnyResult<Fxs>> =>
   op(c => resume(k => {
     const cancels = fxs.map((fx: Fxs[number]) =>
-      runFx(fx, c, (x: AnyResult<Fxs>) => {
+      runFxWith(fx, c, (x: AnyResult<Fxs>) => {
         cancelAll()
         return k(x)
       }))

--- a/src/fail.ts
+++ b/src/fail.ts
@@ -1,5 +1,5 @@
 import { Resume, resume, uncancelable } from './env'
-import { Fx, op, pure, runFx, Use } from './fx'
+import { Fx, op, pure, runFxWith, Use } from './fx'
 
 // ------------------------------------------------------------
 // Fail effect
@@ -16,10 +16,10 @@ export const catchAll = <C1 extends Fail, C2, A, B>(fx: Fx<C1, A>, f: (e: Error)
   op((c): Resume<A | B> => resume(k => {
     const fail = (e: Error) => {
       cancel()
-      return resume(() => runFx(f(e), c, k))
+      return resume(() => runFxWith(f(e), c, k))
     }
 
     let cancel = uncancelable
-    cancel = runFx(fx, { ...c as any, fail }, k)
+    cancel = runFxWith(fx, { ...c as any, fail }, k)
     return cancel
   }))


### PR DESCRIPTION
This allows capability types to be declared without committing to a specific set of dependencies.  The dependencies are derived from the concrete capabilities provided later via `use`.  This means that `use` doesn't only eliminate capabilities, but may also introduce them.

See the echo-console example in this PR for a simple example.