### PR TITLE
feat: implement useWith

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -97,10 +97,15 @@
         "yn": "3.1.1"
       }
     },
+    "ts-toolbelt": {
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-8.0.7.tgz",
+      "integrity": "sha512-KICHyKxc5Nu34kyoODrEe2+zvuQQaubTJz7pnC5RQ19TH/Jged1xv+h8LBrouaSD310m75oAljYs59LNHkLDkQ=="
+    },
     "typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "version": "4.1.0-beta",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.0-beta.tgz",
+      "integrity": "sha512-b/LAttdVl3G6FEmnMkDsK0xvfvaftXpSKrjXn+OVCRqrwz5WD/6QJOiN+dTorqDY+hkaH+r2gP5wI1jBDmdQ7A==",
       "dev": true
     },
     "yn": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "benchmark": "^2.1.4",
     "conditional-type-checks": "^1.0.5",
     "ts-node": "8.10.2",
-    "typescript": "3.9.7"
+    "typescript": "^4.1.0-beta"
+  },
+  "dependencies": {
+    "ts-toolbelt": "^8.0.7"
   }
 }

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,31 +1,35 @@
+import { U, L } from "ts-toolbelt";
+
 // An Env requires a set of capabilities C to compute a result A.
 // Allows using a continuation for flexibility or returning directly
 // for efficiency and stack safety.
-export type Env<C, A> = (c: C) => Resume<A>
+export type Env<C, A> = (c: C) => Resume<A>;
 
-export type Intersect<U> =
-  (U extends any ? (k: U) => void : never) extends ((k: infer I) => void) ? I : never
+export type Intersect<U> = And<U.ListOf<U>>;
+
+type And<As extends readonly any[], S = unknown> = {
+  continue: And<L.Tail<As>, S & L.Head<As>>;
+  end: S;
+}[[] extends As ? "end" : "continue"];
 
 export type Resume<A> =
-  | { now: true, value: A }
-  | { now: false, run: (k: (a: A) => Cancel) => Cancel }
+  | { now: true; value: A }
+  | { now: false; run: (k: (a: A) => Cancel) => Cancel };
 
-export type Cancel = () => void
+export type Cancel = () => void;
 
-export const uncancelable = () => { }
+export const uncancelable = () => {};
 
-export const resumeNow = <A>(value: A): Resume<A> =>
-  ({ now: true, value })
+export const resumeNow = <A>(value: A): Resume<A> => ({ now: true, value });
 
-export const resume = <A>(run: (k: (a: A) => Cancel) => Cancel): Resume<A> =>
-  ({
-    now: false,
-    run: k => {
-      let cancel = uncancelable
-      cancel = run(a => (cancel = k(a)))
-      return () => cancel()
-    }
-  })
+export const resume = <A>(run: (k: (a: A) => Cancel) => Cancel): Resume<A> => ({
+  now: false,
+  run: (k) => {
+    let cancel = uncancelable;
+    cancel = run((a) => (cancel = k(a)));
+    return () => cancel();
+  },
+});
 
 export const runResume = <A>(ra: Resume<A>, k: (a: A) => Cancel): Cancel =>
-  ra.now ? k(ra.value) : ra.run(k)
+  ra.now ? k(ra.value) : ra.run(k);

--- a/src/fx.ts
+++ b/src/fx.ts
@@ -1,6 +1,6 @@
-import { Cancel, Env, Intersect, resume, resumeNow, uncancelable } from './env'
+import { Cancel, Env, Intersect, resume, resumeNow, uncancelable } from "./env";
 
-export const URI: unique symbol = Symbol('@fx-ts/Fx')
+export const URI: unique symbol = Symbol("@fx-ts/Fx");
 
 // Fx represents an effectful computation
 // It's a sequence of effects, each of which requires a set of capabilities.
@@ -13,93 +13,128 @@ export const URI: unique symbol = Symbol('@fx-ts/Fx')
 export interface Fx<C, A> {
   // URI prevents using a native generator directly as an Fx
   // since native generators are stateful and not referentially transparent
-  readonly [URI]: undefined
-  [Symbol.iterator](): Iterator<Env<C, unknown>, A, unknown>
+  readonly [URI]: undefined;
+  [Symbol.iterator](): Iterator<Env<C, unknown>, A, unknown>;
 }
 
 // An Fx that requires no particular capabilities and produces no effects
-export type None = unknown
+export type None = unknown;
 
-export type Effects<F> = F extends Fx<infer C, any> ? unknown extends C ? never : C : never
-export type Return<F> = F extends Fx<any, infer A> ? A : never
+export type Effects<F> = F extends Fx<infer C, any>
+  ? unknown extends C
+    ? never
+    : C
+  : never;
+export type Return<F> = F extends Fx<any, infer A> ? A : never;
 
 // Get the type of capabilities required by Envs
-type Capabilities<E extends Env<any, any>> = Intersect<CapabilitiesOf<E>>
-type CapabilitiesOf<E> = E extends Env<infer C, any> ? C : never
+type Capabilities<E extends Env<any, any>> = Intersect<CapabilitiesOf<E>>;
+type CapabilitiesOf<E> = E extends Env<infer C, any> ? C : never;
 
 // do-notation for effects.
 // Create an Fx from a generator function.
 // Crucially, allows the computation to be started more than once by calling the
 // generator function each time its iterator is requested
-export const doFx = <C, Y extends Env<any, any>, A>(f: (c: C) => Generator<Y, A, unknown>): Fx<C & Capabilities<Y>, A> =>
-  new GenFx(f)
+export const doFx = <C, Y extends Env<any, any>, A>(
+  f: (c: C) => Generator<Y, A, unknown>
+): Fx<C & Capabilities<Y>, A> => new GenFx(f);
 
-class GenFx<C, Y extends Env<any, any>, A> implements Fx<C & Capabilities<Y>, A> {
-  public readonly [URI]: undefined
+class GenFx<C, Y extends Env<any, any>, A>
+  implements Fx<C & Capabilities<Y>, A> {
+  public readonly [URI]: undefined;
 
-  constructor(public readonly gen: (c: C) => Generator<Y, A, unknown>) { }
-  *[Symbol.iterator](): Iterator<Env<C & Capabilities<Y>, unknown>, A, unknown> {
-    return yield* this.gen(yield* get<C>())
+  constructor(public readonly gen: (c: C) => Generator<Y, A, unknown>) {}
+  *[Symbol.iterator](): Iterator<
+    Env<C & Capabilities<Y>, unknown>,
+    A,
+    unknown
+  > {
+    return yield* this.gen(yield* get<C>());
   }
 }
 
 // Create a simple effect operation from an Env
-export const op = <C, A>(env: Env<C, A>): Fx<C, A> => new OpFx(env)
+export const op = <C, A>(env: Env<C, A>): Fx<C, A> => new OpFx(env);
 
 class OpFx<C, A> implements Fx<C, A> {
-  public readonly [URI]: undefined
+  public readonly [URI]: undefined;
 
-  constructor(public readonly env: Env<C, A>) { }
+  constructor(public readonly env: Env<C, A>) {}
   *[Symbol.iterator](): Iterator<Env<C, A>, A, A> {
-    return yield this.env
+    return yield this.env;
   }
 }
 
 // Create an Fx that returns A, with no effects and requires
 // no particular environment
-export const pure = <A>(a: A): Fx<None, A> => new PureFx(a)
+export const pure = <A>(a: A): Fx<None, A> => new PureFx(a);
 
 class PureFx<A> implements Fx<None, A>, Iterator<never, A, never> {
-  public readonly [URI]: undefined
-  public readonly done: true = true
+  public readonly [URI]: undefined;
+  public readonly done: true = true;
 
-  constructor(public readonly value: A) { }
-  [Symbol.iterator]() { return this }
-  next() { return this }
-}
-
-// Run an Fx by providing its remaining capability requirements
-export const runFx = <C, A>(fx: Fx<C, A>, c: C, k: (r: A) => Cancel = () => uncancelable): Cancel => {
-  const i = fx[Symbol.iterator]()
-  return stepFx(i, i.next(), c, k)
-}
-
-// Process synchronous and asynchronous effects in constant stack
-const stepFx = <C, A>(i: Iterator<Env<C, unknown>, A, unknown>, ir: IteratorResult<Env<C, unknown>, A>, c: C, k: (r: A) => Cancel): Cancel => {
-  while (true) {
-    if (ir.done) return k(ir.value)
-
-    const r = ir.value(c)
-    if (!r.now) return r.run(x => stepFx(i, i.next(x), c, k))
-
-    ir = i.next(r.value)
+  constructor(public readonly value: A) {}
+  [Symbol.iterator]() {
+    return this;
+  }
+  next() {
+    return this;
   }
 }
 
+// Run an Fx by providing its remaining capability requirements
+export const runFx = <C, A>(
+  fx: Fx<C, A>,
+  c: C,
+  k: (r: A) => Cancel = () => uncancelable
+): Cancel => {
+  const i = fx[Symbol.iterator]();
+  return stepFx(i, i.next(), c, k);
+};
+
+// Process synchronous and asynchronous effects in constant stack
+const stepFx = <C, A>(
+  i: Iterator<Env<C, unknown>, A, unknown>,
+  ir: IteratorResult<Env<C, unknown>, A>,
+  c: C,
+  k: (r: A) => Cancel
+): Cancel => {
+  while (true) {
+    if (ir.done) return k(ir.value);
+
+    const r = ir.value(c);
+    if (!r.now) return r.run((x) => stepFx(i, i.next(x), c, k));
+
+    ir = i.next(r.value);
+  }
+};
+
 // Request part of the environment by type
-export const get = <C>() => op<C, C>(resumeNow)
+export const get = <C>() => op<C, C>(resumeNow);
 
 // Subtract CP from CR
-export type Use<CR, CP> =
-  CP extends CR ? None
-  : CR extends CP ? Omit<CR, keyof CP>
-  : CR
+export type Use<CR, CP> = CP extends CR
+  ? None
+  : CR extends CP
+  ? Omit<CR, keyof CP>
+  : CR;
 
 // Satisfy some or all of an Fx's required capabilities.
-export const use = <CR extends CP, CP, A>(fx: Fx<CR, A>, cp: CP): Fx<Use<CR, CP>, A> =>
-  embed(fx, (c: Use<CR, CP>): CR => ({ ...c as any, ...cp }))
+export const use = <CR extends CP, CP, A>(
+  fx: Fx<CR, A>,
+  cp: CP
+): Fx<Use<CR, CP>, A> =>
+  embed(fx, (c: Use<CR, CP>): CR => ({ ...(c as any), ...cp }));
+
+export const useWith = <C1, C2, C3, A>(
+  provider: Fx<C1, C2>,
+  fx: Fx<C2 & C3, A>
+): Fx<C1 & C3, A> =>
+  op((c) =>
+    resume((k) => runFx(provider, c, (c2) => runFx(fx, { ...c, ...c2 }, k)))
+  );
 
 // Adapt an Fx that requires one set of capabilities to
 // an environment that provides a different set.
 export const embed = <C0, C1, A>(fx: Fx<C1, A>, f: (c: C0) => C1): Fx<C0, A> =>
-  op(c0 => resume(k => runFx(fx, f(c0), k)))
+  op((c0) => resume((k) => runFx(fx, f(c0), k)));


### PR DESCRIPTION
This is a rough draft at providing `useWith` a function for using an effect to produce capabilities for the use in another effect. It also makes some adjustments to allow for using a recursive type to manage the intersections to produce cleaner output around the `Intersect<A | unknown>` which was not previously equal to `A & unknown`. 

Sorry about all of the extra formatting noise my editor keeps inserting. Perhaps it'd be worthwhile to add eslint, prettier, etc?